### PR TITLE
feat: Add battle result game UI with responsive design

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,63 @@
-import Image from "next/image";
+import Link from 'next/link'
 
 export default function Home() {
-  return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const exampleBattles = [
+    {
+      boss: 'Lady Delayna',
+      playerScore: 150,
+      bossScore: 120,
+      result: 'Victory'
+    },
+    {
+      boss: 'Phantom Tax',
+      playerScore: 80,
+      bossScore: 100,
+      result: 'Defeat'
+    }
+  ]
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-900 to-black flex items-center justify-center p-4">
+      <div className="text-center w-full">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-white mb-6 sm:mb-8">Battle Results Demo</h1>
+        
+        <div className="space-y-3 sm:space-y-4 max-w-2xl mx-auto">
+          <p className="text-sm sm:text-base text-gray-300 mb-6 sm:mb-8 px-2">
+            Click on any battle result below to view the result page
+          </p>
+          
+          {exampleBattles.map((battle, index) => (
+            <Link
+              key={index}
+              href={`/result?bossname=${encodeURIComponent(battle.boss)}&scoreplayer=${battle.playerScore}&scoreboss=${battle.bossScore}`}
+              className="block bg-gray-800 hover:bg-gray-700 transition-colors rounded-lg p-4 sm:p-6 text-left mx-2 sm:mx-0"
+            >
+              <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2 sm:gap-0">
+                <div>
+                  <h3 className="text-lg sm:text-xl font-semibold text-white mb-1 sm:mb-2">
+                    vs {battle.boss}
+                  </h3>
+                  <p className="text-sm sm:text-base text-gray-400">
+                    Player: {battle.playerScore} | Boss: {battle.bossScore}
+                  </p>
+                </div>
+                <div className={`text-xl sm:text-2xl font-bold ${
+                  battle.result === 'Victory' ? 'text-green-500' : 'text-red-500'
+                }`}>
+                  {battle.result}
+                </div>
+              </div>
+            </Link>
+          ))}
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+        
+        <div className="mt-8 sm:mt-12 text-gray-400 px-4">
+          <p className="text-sm sm:text-base">Example URLs:</p>
+          <code className="block mt-2 text-xs sm:text-sm bg-gray-800 p-3 sm:p-4 rounded break-all">
+            /result?bossname=Lady%20Delayna&scoreplayer=150&scoreboss=120
+          </code>
+        </div>
+      </div>
     </div>
-  );
+  )
 }

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -15,9 +15,9 @@ function getBossImage(bossname?: string): string {
   
   switch (bossname?.toLowerCase()) {
     case 'lady delayna':
-      return 'https://pub-7816c9687d9b47a894436af0a6cc0309.r2.dev/background.png'
+      return process.env.NEXT_PUBLIC_LADY_DELAYNA_OG_IMAGE || 'https://pub-7816c9687d9b47a894436af0a6cc0309.r2.dev/background.png'
     case 'phantom tax':
-      return 'https://pub-7816c9687d9b47a894436af0a6cc0309.r2.dev/Card.png'
+      return process.env.NEXT_PUBLIC_PHANTOM_TAX_OG_IMAGE || 'https://pub-7816c9687d9b47a894436af0a6cc0309.r2.dev/Card.png'
     case 'dragon':
       return `${baseUrl}/images/dragon-boss.jpg`
     case 'wizard':
@@ -116,10 +116,10 @@ async function ResultContent({ searchParams }: ResultPageProps) {
       {/* Main content */}
       <div className="relative z-10 w-full max-w-4xl mx-auto px-4">
         {/* Battle display */}
-        <div className="flex items-center justify-between max-w-5xl mx-auto mb-12">
+        <div className="flex items-center justify-between max-w-5xl mx-auto mb-8 sm:mb-12 px-2 sm:px-4">
           {/* Player side */}
-          <div className="flex flex-col items-center w-48">
-            <div className="w-24 h-24 sm:w-28 sm:h-28 md:w-32 md:h-32 relative mb-4">
+          <div className="flex flex-col items-center flex-1 max-w-[120px] sm:max-w-[150px] md:max-w-none md:w-48">
+            <div className="w-20 h-20 sm:w-24 sm:h-24 md:w-32 md:h-32 relative mb-2 sm:mb-4">
               <Image
                 src="/player.png"
                 alt="Player"
@@ -128,20 +128,20 @@ async function ResultContent({ searchParams }: ResultPageProps) {
                 className="object-contain"
               />
             </div>
-            <h3 className="text-white text-lg md:text-xl font-bold mb-4">Player</h3>
-            <div className="bg-blue-600 px-6 py-3 rounded-xl min-w-[80px] flex justify-center">
-              <span className="text-white text-2xl sm:text-3xl font-bold">{playerScore}</span>
+            <h3 className="text-white text-sm sm:text-base md:text-xl font-bold mb-2 sm:mb-4">Player</h3>
+            <div className="bg-blue-600 px-3 sm:px-4 md:px-6 py-2 sm:py-3 rounded-lg sm:rounded-xl min-w-[60px] sm:min-w-[80px] flex justify-center">
+              <span className="text-white text-lg sm:text-xl md:text-2xl font-bold">{playerScore}</span>
             </div>
           </div>
 
           {/* VS */}
-          <div className="flex items-center justify-center">
-            <h2 className="text-4xl md:text-6xl font-bold text-white transform -skew-x-12">VS</h2>
+          <div className="flex items-center justify-center mx-2 sm:mx-4">
+            <h2 className="text-2xl sm:text-3xl md:text-6xl font-bold text-white transform -skew-x-12">VS</h2>
           </div>
 
           {/* Boss side */}
-          <div className="flex flex-col items-center w-48">
-            <div className="w-24 h-24 sm:w-28 sm:h-28 md:w-32 md:h-32 relative mb-4">
+          <div className="flex flex-col items-center flex-1 max-w-[120px] sm:max-w-[150px] md:max-w-none md:w-48">
+            <div className="w-20 h-20 sm:w-24 sm:h-24 md:w-32 md:h-32 relative mb-2 sm:mb-4">
               {bossCharacterImage ? (
                 <Image
                   src={bossCharacterImage}
@@ -156,9 +156,9 @@ async function ResultContent({ searchParams }: ResultPageProps) {
                 </div>
               )}
             </div>
-            <h3 className="text-white text-lg md:text-xl font-bold mb-4 uppercase text-center">{bossname || 'Boss'}</h3>
-            <div className={`${isPhantomTax ? 'bg-red-600' : 'bg-purple-600'} px-6 py-3 rounded-xl min-w-[80px] flex justify-center`}>
-              <span className="text-white text-2xl sm:text-3xl font-bold">{bossScore}</span>
+            <h3 className="text-white text-xs sm:text-base md:text-xl font-bold mb-2 sm:mb-4 uppercase text-center break-words">{bossname || 'Boss'}</h3>
+            <div className={`${isPhantomTax ? 'bg-red-600' : 'bg-purple-600'} px-3 sm:px-4 md:px-6 py-2 sm:py-3 rounded-lg sm:rounded-xl min-w-[60px] sm:min-w-[80px] flex justify-center`}>
+              <span className="text-white text-lg sm:text-xl md:text-2xl font-bold">{bossScore}</span>
             </div>
           </div>
         </div>
@@ -166,9 +166,9 @@ async function ResultContent({ searchParams }: ResultPageProps) {
         {/* Result section */}
         <div className="text-center">
           <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-white">คุณได้รับชัยชนะ</h1>
-          <p className="text-base sm:text-lg md:text-xl text-gray-200 mb-8 px-4">
-            ชัยชนะที่ได้รับสามารถต่อยอดไปในธุรกิจจริง<br />
-            ปรึกษาเรา DEVSMITH ช่วยได้
+          <p className="text-sm sm:text-base md:text-xl text-gray-200 mb-6 sm:mb-8 px-4">
+            ชัยชนะที่ได้รับสามารถต่อยอดไปในธุรกิจจริง<br className="hidden sm:block" />
+            <span className="block sm:inline">ปรึกษาเรา DEVSMITH ช่วยได้</span>
           </p>
           
           {/* Result badge */}


### PR DESCRIPTION
## Summary
- Implemented a battle result display system with VS-style UI
- Added responsive design for optimal mobile and desktop experience
- Integrated Thai font support and boss-specific themes

## Changes Made

### Main Page (`/`)
- Created a view-only demo page with example battle results
- Added clickable battle cards that link to result pages
- Implemented responsive layout for mobile devices

### Result Page (`/result`)
- Built VS-style battle display with player and boss avatars
- Added dynamic backgrounds based on boss type:
  - Lady Delayna: Blue to purple gradient
  - Phantom Tax: Blue to purple to red gradient
- Integrated character images for player and bosses
- Implemented responsive design with scaling avatars and text

### Technical Improvements
- Added Kanit Google Font for proper Thai text rendering
- Extracted OpenGraph image URLs to environment variables
- Implemented proper async handling for Next.js 15 searchParams
- Added TypeScript interfaces for type safety

### Boss Support
- Lady Delayna with custom OpenGraph image
- Phantom Tax with custom OpenGraph image and red-themed UI
- Placeholder support for additional bosses (Dragon, Wizard, Knight, Demon)

## Test Plan
- [ ] Test result page with different boss names and scores
- [ ] Verify responsive design on mobile devices
- [ ] Check OpenGraph image rendering for social media sharing
- [ ] Ensure Thai text displays correctly with Kanit font
- [ ] Test navigation from main page to result pages

🤖 Generated with [Claude Code](https://claude.ai/code)